### PR TITLE
Get platform-specific classpath separator

### DIFF
--- a/src/main/scala/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/CxfWsdl2JavaPlugin.scala
@@ -50,7 +50,7 @@ object CxfWsdl2JavaPlugin extends Plugin {
       // définition de la tâche wsdl2java
       wsdl2java := {
         val s: TaskStreams = streams.value
-        val classpath : String = (((managedClasspath in wsdl2java).value).files).map(_.getAbsolutePath).mkString(":")
+        val classpath : String = (((managedClasspath in wsdl2java).value).files).map(_.getAbsolutePath).mkString(System.getProperty("path.separator"))
         val basedir : File = target.value / "cxf"
         IO.createDirectory(basedir)
         wsdls.value.par.foreach { wsdl =>


### PR DESCRIPTION
Get classpath separator from path.separator system property so Windows is supported where separator is ; not previously hard-coded :
