### PR TITLE
Cope with output file including spaces in the path

### DIFF
--- a/src/main/scala/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/CxfWsdl2JavaPlugin.scala
@@ -61,7 +61,9 @@ object CxfWsdl2JavaPlugin extends Plugin {
             s.log.debug("Removing output directory for " + id + " ...")
             IO.delete(output)
             s.log.info("Compiling " + id)
-            "java -cp \""+classpath+"\" -Dfile.encoding=UTF-8 org.apache.cxf.tools.wsdlto.WSDLToJava "+args.mkString(" ") ! s.log
+            val cmd = Seq("java", "-cp", classpath, "-Dfile.encoding=UTF-8", "org.apache.cxf.tools.wsdlto.WSDLToJava") ++ args
+            s.log.debug(cmd.toString())
+            cmd ! s.log
             s.log.info("Finished " + id)
           }
           else{


### PR DESCRIPTION
Using implicit String to ProcessBuilder conversion is pretty dangerous IMHO.   Much safer to build a Seq[String] and use that.  Then there's no need to do things like wrapping the classpath in quotes.

Without this if the output file includes a space in the path then somewhat confusingly you get WSDL2Java complaining about -verbose.
