### PR TITLE
Convert to AutoPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,10 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
-
 .cache
-
 .classpath
-
 .project
-
 .settings/org.eclipse.core.resources.prefs
+
+# IDEA specific
+.idea/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ an sbt plugin for generating java artifacts from WSDL using cxf
 
 ## Requirements
 
-* [SBT 0.13+](http://www.scala-sbt.org/)
+* [SBT 0.13.5+](http://www.scala-sbt.org/)
 
 
 ## Quick start
@@ -16,32 +16,20 @@ Add plugin to *project/plugins.sbt*:
 
 resolvers += "Sonatype Repository" at "https://oss.sonatype.org/content/groups/public"
 
-addSbtPlugin("com.ebiznext.sbt.plugins" % "sbt-cxf-wsdl2java" % "0.1.4")
-```
-
-For *.sbt* build definitions, inject the plugin settings in *build.sbt*:
-
-```scala
-seq(cxf.settings :_*)
-```
-
-For *.scala* build definitions, inject the plugin settings in *Build.scala*:
-
-```scala
-Project(..., settings = Project.defaultSettings ++ com.ebiznext.sbt.plugins.CxfWsdl2JavaPlugin.cxf.settings)
+addSbtPlugin("com.ebiznext.sbt.plugins" % "sbt-cxf-wsdl2java" % "0.1.5")
 ```
 
 ## Configuration
 
-Plugin keys are located in `com.ebiznext.sbt.plugins.CxfWsdl2JavaPlugin.Keys`
+Plugin keys are prefixed with "cxf".
 
 ### Add Wsdls
 
 ```scala
 lazy val wsclientPackage := "com.ebiznext.sbt.sample"
 
-cxf.wsdls := Seq(
-      cxf.Wsdl((resourceDirectory in Compile).value / "Sample.wsdl", Seq("-p",  wsclientPackage), "unique wsdl id"),
+cxfWsdls := Seq(
+      CxfWsdl((resourceDirectory in Compile).value / "Sample.wsdl", Seq("-p",  wsclientPackage), "unique wsdl id"),
       ...
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.ebiznext.sbt.plugins"
 
 version := "0.1.5-SNAPSHOT"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.4"
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-cxf-wsdl2java"
 
 organization := "com.ebiznext.sbt.plugins"
 
-version := "0.1.4"
+version := "0.1.5-SNAPSHOT"
 
 scalaVersion := "2.10.2"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbtVersion=0.13.9
+sbt.version=0.13.9
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbtVersion=0.13.0
+sbtVersion=0.13.9
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,0 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
-

--- a/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
@@ -53,12 +53,8 @@ object CxfWsdl2JavaPlugin extends AutoPlugin {
     // définition de la tâche wsdl2java
     wsdl2java := {
       val s: TaskStreams = streams.value
-      println(s"managedClasspath ${managedClasspath.in(wsdl2java).value}")
-      println(s"sourceManaged: ${sourceManaged.value}")
       val classpath: String = (((managedClasspath in wsdl2java).value).files).map(_.getAbsolutePath).mkString(System.getProperty("path.separator"))
-      println(s"classpath: ${classpath}")
       val basedir: File = target.value / "cxf"
-      println(s"basedir $basedir")
       IO.createDirectory(basedir)
       cxfWsdls.value.par.foreach { wsdl =>
         val output: File = wsdl.outputDirectory(basedir)

--- a/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
@@ -18,7 +18,7 @@ object CxfWsdl2JavaPlugin extends Plugin {
     lazy val wsdl2java = taskKey[Seq[File]]("Generates java files from wsdls")
     lazy val wsdls = settingKey[Seq[cxf.Wsdl]]("wsdls to generate java files from")
 
-  }  
+  }
 
   private object CxfDefaults extends Keys {
     val settings = Seq(
@@ -40,7 +40,7 @@ object CxfWsdl2JavaPlugin extends Plugin {
     }
 
     val settings = Seq(ivyConfigurations += Config) ++ CxfDefaults.settings ++ Seq(
-      // initialisation de la clef correspondante au répertoire source dans lequel les fichiers générés seront copiés 
+      // initialisation de la clef correspondante au répertoire source dans lequel les fichiers générés seront copiés
       sourceManaged in Config := sourceManaged.value / "cxf",
       // ajout de ce répertoire dans la liste des répertoires source à prendre en compte lors de la compilation
       managedSourceDirectories in Compile += {(sourceManaged in Config).value},

--- a/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
@@ -20,9 +20,9 @@ object CxfWsdl2JavaPlugin extends AutoPlugin {
 
     lazy val cxfVersion = settingKey[String]("cxf version")
     lazy val wsdl2java = taskKey[Seq[File]]("Generates java files from wsdls")
-    lazy val wsdls = settingKey[Seq[Wsdl]]("wsdls to generate java files from")
+    lazy val cxfWsdls = settingKey[Seq[CxfWsdl]]("wsdls to generate java files from")
 
-    case class Wsdl(file: File, args: Seq[String], key: String) {
+    case class CxfWsdl(file: File, args: Seq[String], key: String) {
       def outputDirectory(basedir: File) = new File(basedir, key).getAbsoluteFile
     }
 
@@ -31,13 +31,13 @@ object CxfWsdl2JavaPlugin extends AutoPlugin {
   import autoImport._
 
   val cxfDefaults: Seq[Def.Setting[_]] = Seq(
-    cxfVersion := "2.7.3",
+    cxfVersion := "3.1.2",
     libraryDependencies ++= Seq(
       "org.apache.cxf" % "cxf-tools-wsdlto-core" % cxfVersion.value % CxfConfig.name,
       "org.apache.cxf" % "cxf-tools-wsdlto-databinding-jaxb" % cxfVersion.value % CxfConfig.name,
       "org.apache.cxf" % "cxf-tools-wsdlto-frontend-jaxws" % cxfVersion.value % CxfConfig.name
     ),
-    wsdls := Nil
+    cxfWsdls := Nil
   )
 
   private lazy val cxfConfig = Seq(
@@ -60,7 +60,7 @@ object CxfWsdl2JavaPlugin extends AutoPlugin {
       val basedir: File = target.value / "cxf"
       println(s"basedir $basedir")
       IO.createDirectory(basedir)
-      wsdls.value.par.foreach { wsdl =>
+      cxfWsdls.value.par.foreach { wsdl =>
         val output: File = wsdl.outputDirectory(basedir)
         if (wsdl.file.lastModified() > output.lastModified()) {
           val id: String = wsdl.key

--- a/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
@@ -1,78 +1,88 @@
 package com.ebiznext.sbt.plugins
 
-import sbt._
-import sbt.Keys._
 import java.io.File
+
+import sbt.Keys._
+import sbt._
 
 /**
  * @author stephane.manciot@ebiznext.com
  *
  */
-object CxfWsdl2JavaPlugin extends Plugin {
+object CxfWsdl2JavaPlugin extends AutoPlugin {
 
-  trait Keys {
+  override def requires = sbt.plugins.JvmPlugin
 
-    lazy val Config = config("cxf") extend(Compile) hide
+  override def trigger = allRequirements
+
+  object autoImport {
+    lazy val CxfConfig = config("cxf").hide
 
     lazy val cxfVersion = settingKey[String]("cxf version")
     lazy val wsdl2java = taskKey[Seq[File]]("Generates java files from wsdls")
-    lazy val wsdls = settingKey[Seq[cxf.Wsdl]]("wsdls to generate java files from")
-
-  }
-
-  private object CxfDefaults extends Keys {
-    val settings = Seq(
-      cxfVersion := "2.7.3",
-      libraryDependencies ++= Seq[ModuleID](
-        "org.apache.cxf" % "cxf-tools-wsdlto-core" % cxfVersion.value % Config.name,
-        "org.apache.cxf" % "cxf-tools-wsdlto-databinding-jaxb" % cxfVersion.value % Config.name,
-        "org.apache.cxf" % "cxf-tools-wsdlto-frontend-jaxws" % cxfVersion.value % Config.name
-      ),
-      wsdls := Nil
-    )
-  }
-
-  // to avoid namespace clashes, use a nested object
-  object cxf extends Keys {
+    lazy val wsdls = settingKey[Seq[Wsdl]]("wsdls to generate java files from")
 
     case class Wsdl(file: File, args: Seq[String], key: String) {
       def outputDirectory(basedir: File) = new File(basedir, key).getAbsoluteFile
     }
 
-    val settings = Seq(ivyConfigurations += Config) ++ CxfDefaults.settings ++ Seq(
-      // initialisation de la clef correspondante au répertoire source dans lequel les fichiers générés seront copiés
-      sourceManaged in Config := sourceManaged.value / "cxf",
-      // ajout de ce répertoire dans la liste des répertoires source à prendre en compte lors de la compilation
-      managedSourceDirectories in Compile += {(sourceManaged in Config).value},
-      managedClasspath in wsdl2java <<= (classpathTypes in wsdl2java, update) map { (ct, report) =>
-          Classpaths.managedJars(Config, ct, report)
-      },
-      // définition de la tâche wsdl2java
-      wsdl2java := {
-        val s: TaskStreams = streams.value
-        val classpath : String = (((managedClasspath in wsdl2java).value).files).map(_.getAbsolutePath).mkString(System.getProperty("path.separator"))
-        val basedir : File = target.value / "cxf"
-        IO.createDirectory(basedir)
-        wsdls.value.par.foreach { wsdl =>
-          val output : File = wsdl.outputDirectory(basedir)
-          if(wsdl.file.lastModified() > output.lastModified()) {
-            val id : String = wsdl.key
-            val args : Seq[String] = Seq("-d", output.getAbsolutePath, "-verbose", "-autoNameResolution", "-exsh", "true", "-fe", "jaxws21", "-client") ++ wsdl.args :+ wsdl.file.getAbsolutePath
-            s.log.debug("Removing output directory for " + id + " ...")
-            IO.delete(output)
-            s.log.info("Compiling " + id)
-            val cmd = Seq("java", "-cp", classpath, "-Dfile.encoding=UTF-8", "org.apache.cxf.tools.wsdlto.WSDLToJava") ++ args
-            s.log.debug(cmd.toString())
-            cmd ! s.log
-            s.log.info("Finished " + id)
-          }
-          else{
-            s.log.debug("Skipping " + wsdl.key)
-          }
-          IO.copyDirectory(output, (sourceManaged in Config).value, true)
-        }
-        ((sourceManaged in Config).value ** "*.java").get
-      },
-      sourceGenerators in Compile <+= wsdl2java)
   }
+
+  import autoImport._
+
+  val cxfDefaults: Seq[Def.Setting[_]] = Seq(
+    cxfVersion := "2.7.3",
+    libraryDependencies ++= Seq(
+      "org.apache.cxf" % "cxf-tools-wsdlto-core" % cxfVersion.value % CxfConfig.name,
+      "org.apache.cxf" % "cxf-tools-wsdlto-databinding-jaxb" % cxfVersion.value % CxfConfig.name,
+      "org.apache.cxf" % "cxf-tools-wsdlto-frontend-jaxws" % cxfVersion.value % CxfConfig.name
+    ),
+    wsdls := Nil
+  )
+
+  private lazy val cxfConfig = Seq(
+    // initialisation de la clef correspondante au répertoire source dans lequel les fichiers générés seront copiés
+    sourceManaged in CxfConfig := sourceManaged.value / "cxf",
+    // ajout de ce répertoire dans la liste des répertoires source à prendre en compte lors de la compilation
+    managedSourceDirectories in Compile += {
+      (sourceManaged in CxfConfig).value
+    },
+    managedClasspath in wsdl2java <<= (classpathTypes in wsdl2java, update).map { (ct, report) =>
+      Classpaths.managedJars(CxfConfig, ct, report)
+    },
+    // définition de la tâche wsdl2java
+    wsdl2java := {
+      val s: TaskStreams = streams.value
+      println(s"managedClasspath ${managedClasspath.in(wsdl2java).value}")
+      println(s"sourceManaged: ${sourceManaged.value}")
+      val classpath: String = (((managedClasspath in wsdl2java).value).files).map(_.getAbsolutePath).mkString(System.getProperty("path.separator"))
+      println(s"classpath: ${classpath}")
+      val basedir: File = target.value / "cxf"
+      println(s"basedir $basedir")
+      IO.createDirectory(basedir)
+      wsdls.value.par.foreach { wsdl =>
+        val output: File = wsdl.outputDirectory(basedir)
+        if (wsdl.file.lastModified() > output.lastModified()) {
+          val id: String = wsdl.key
+          val args: Seq[String] = Seq("-d", output.getAbsolutePath, "-verbose", "-autoNameResolution", "-exsh", "true", "-fe", "jaxws21", "-client") ++ wsdl.args :+ wsdl.file.getAbsolutePath
+          s.log.debug("Removing output directory for " + id + " ...")
+          IO.delete(output)
+          s.log.info("Compiling " + id)
+          val cmd = Seq("java", "-cp", classpath, "-Dfile.encoding=UTF-8", "org.apache.cxf.tools.wsdlto.WSDLToJava") ++ args
+          s.log.debug(cmd.toString())
+          cmd ! s.log
+          s.log.info("Finished " + id)
+        }
+        else {
+          s.log.debug("Skipping " + wsdl.key)
+        }
+        IO.copyDirectory(output, (sourceManaged in CxfConfig).value, true)
+      }
+      ((sourceManaged in CxfConfig).value ** "*.java").get
+    },
+    sourceGenerators in Compile <+= wsdl2java
+  )
+
+  override lazy val projectSettings =
+    Seq(ivyConfigurations += CxfConfig) ++ cxfDefaults ++ inConfig(Compile)(cxfConfig)
 }


### PR DESCRIPTION
This pull request does a few things:
 - converts the plugin to an [AutoPlugin](http://www.scala-sbt.org/0.13/docs/Plugins.html)
 - bumps the default CXF version used to 3.1.2
 - changes the settings keys to use a plugin-specific prefix as [recommended](http://www.scala-sbt.org/0.13/docs/Plugins-Best-Practices.html#Avoid+namespace+clashes) in the sbt reference manual
 - moves the code into a directory structure conforming to the package structure
 - remove the eclipse plugin from the project
 - update .gitignore to ignore IDEA specific directories

If you'd prefer me to split any of these out of this admittedly pretty big (scope-wise) pull request I'd be happy to do so.