### PR TITLE
Update CxfWsdl2JavaPlugin.scala

### DIFF
--- a/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala
@@ -16,7 +16,7 @@ object CxfWsdl2JavaPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
-    lazy val CxfConfig = config("cxf").hide
+    lazy val cxfConfig = config("cxfConfig").hide
 
     lazy val cxfVersion = settingKey[String]("cxf version")
     lazy val wsdl2java = taskKey[Seq[File]]("Generates java files from wsdls")


### PR DESCRIPTION
From Gitter chat:

mkotsbak https://github.com/ebiznext/sbt-cxf-wsdl2java/blob/master/src/main/scala/com/ebiznext/sbt/plugins/CxfWsdl2JavaPlugin.scala#L19
libraryDependencies in CxfConfig +=
in root *.sbt
not in project/*.sbt
these kind of incosistencies really bother me..
my not make it val CxfConfig = config("CxfConfig")...